### PR TITLE
Test json method

### DIFF
--- a/lib/trubl/api/touts.rb
+++ b/lib/trubl/api/touts.rb
@@ -51,7 +51,7 @@ module Trubl
         return [] if uids.blank?
 
         requests = uids.in_groups_of(100, false).collect do |uid_group|
-          {path: "touts", query: {uids: uid_group.join(',')} }
+          {path: "touts.json", query: {uids: uid_group.join(',')} }
         end
 
         multi_request(:get, requests).

--- a/lib/trubl/api/touts.rb
+++ b/lib/trubl/api/touts.rb
@@ -46,6 +46,20 @@ module Trubl
           compact
       end
 
+      def retrieve_touts_json(uids=[])
+        uids = (uids.is_a?(Array) ? uids : [uids]).compact.uniq.sort
+        return [] if uids.blank?
+
+        requests = uids.in_groups_of(100, false).collect do |uid_group|
+          {path: "touts", query: {uids: uid_group.join(',')} }
+        end
+
+        multi_request(:get, requests).
+          collect { |response| response }.
+          flatten.
+          compact
+      end
+
       # returns Array of Trubl::Tout instances or nil
       def filter_touts(params={})
         #raise "tout_uids AND/OR user_uids are required params" if params[:tout_uids].blank? && params[:user_uids].blank?

--- a/lib/trubl/api/touts.rb
+++ b/lib/trubl/api/touts.rb
@@ -55,7 +55,6 @@ module Trubl
         end
 
         multi_request(:get, requests).
-          collect { |response| response }.
           flatten.
           compact
       end


### PR DESCRIPTION
Add a json version of the retrieve_touts method to bypass creating Trubl::Touts when they are not required.